### PR TITLE
fixes #12

### DIFF
--- a/src/IOM_newsAPI_query.jl
+++ b/src/IOM_newsAPI_query.jl
@@ -12,6 +12,9 @@ module IOM_newsAPI_query
 
     include("filter_userhaspermissions.jl")
     include("query_newsapi.jl")
+    include("query_newsapi_helper.jl")
+
+    include("splitKeywords/split_keywords.jl")
 
     export query_newsapi
 end

--- a/src/query_newsapi.jl
+++ b/src/query_newsapi.jl
@@ -1,9 +1,11 @@
 """
-Writes and executes a query to the eventregistry articles API.
+Splits long lists of keywords into smaller batches and runs a query on each batch. Then rejoins them back into one DataFrame. When this happens, the `relevance` column will not be as useful, as the external API does not know the full query. 
 kws = user["keywords"]
 keywords = kws["keywords"]
 locations = kws["locations"]
 languages = kws["languages"]
+concepts = kws["concepts"]
+sources = kws["sources"]
 # Arguments
 - `user::Dict`: Built to be compatible with the `user` table. It must have the field "keywords"=>Dict("keywords", "locations", "languages") (TODO: Remove explicit need for languages fields, consider keeping keywords and locations to prevent accidentally querying large numbers of results.)
 - `dates::Tuple{Date}`: (startDate, endDate) of query.
@@ -11,22 +13,16 @@ languages = kws["languages"]
 - `sortby::String`: The value to sort article return order by.
 """
 function query_newsapi(user::Dict, dates::Tuple{Date, Date}, num_articles::Int, sortby::String; debug=false)
-
-    query_str = isnothing(sortby) ? write_api_request(user, dates) : write_api_request(user, dates, sortby=sortby)
-    if debug
-        println(JSON.json(query_str))
+    kws = user["keywords"]
+    batches = split_keywords(kws["keywords"])
+    users = [deepcopy(user) for _ in batches]
+    for (i, b) in enumerate(batches)
+        users[i]["keywords"]["keywords"]=b
     end
-    res_pg_1 = execute_query(query_str, authentication(),1) # Query 1 first, as it returns the total number of articles from a query
+    arts = query_newsapi_helper.(users, [dates], [num_articles], [sortby], debug=debug)
+    all_arts = vcat(arts...) 
 
-    num_pages = calculate_pages(res_pg_1, num_articles, debug=debug)
-
-    res_pgs = execute_query.([query_str],[authentication()], 2:num_pages) # In future, this might be parralellised
-    
-    all_pages = vcat(res_pg_1["articles"]["results"], [res["articles"]["results"] for res in res_pgs]...)
-
-    filtered = filter_userhaspermissions.(all_pages)
-    min_idx = min(length(filtered),num_articles)
-    return filtered[1:min_idx]
+    return unique([a for a in all_arts if typeof(a)<:Dict])
 end
 
 

--- a/src/query_newsapi_helper.jl
+++ b/src/query_newsapi_helper.jl
@@ -1,0 +1,32 @@
+"""
+A function that executes the main body of code for query_newsapi. It exists so that it can be broadcasted to when long lists of keywords have been split into smaller batches.
+Writes and executes a query to the eventregistry articles API.
+kws = user["keywords"]
+keywords = kws["keywords"]
+locations = kws["locations"]
+languages = kws["languages"]
+# Arguments
+- `user::Dict`: Built to be compatible with the `user` table. It must have the field "keywords"=>Dict("keywords", "locations", "languages") (TODO: Remove explicit need for languages fields, consider keeping keywords and locations to prevent accidentally querying large numbers of results.)
+- `dates::Tuple{Date}`: (startDate, endDate) of query.
+- `num_articles::Int`: Maximum number of articles queried (rounded up to nearest 100 as there are 100 articles per page and each query costs the same). 
+- `sortby::String`: The value to sort article return order by.
+
+"""
+function query_newsapi_helper(user::Dict, dates::Tuple{Date, Date}, num_articles::Int, sortby::String; debug=false)
+
+    query_str = isnothing(sortby) ? write_api_request(user, dates) : write_api_request(user, dates, sortby=sortby)
+    if debug
+        println(JSON.json(query_str))
+    end
+    res_pg_1 = execute_query(query_str, authentication(),1) # Query 1 first, as it returns the total number of articles from a query
+
+    num_pages = calculate_pages(res_pg_1, num_articles, debug=debug)
+
+    res_pgs = execute_query.([query_str],[authentication()], 2:num_pages) # In future, this might be parralellised
+    
+    all_pages = vcat(res_pg_1["articles"]["results"], [res["articles"]["results"] for res in res_pgs]...)
+
+    filtered = filter_userhaspermissions.(all_pages)
+    min_idx = min(length(filtered),num_articles)
+    return filtered[1:min_idx]
+end

--- a/src/splitKeywords/split_keywords.jl
+++ b/src/splitKeywords/split_keywords.jl
@@ -1,0 +1,31 @@
+"""
+A function to split a long list of keywords into multiple, each below the maximum limit of 60. This is the total number of words in the query, not the number of phrases used, for example "amazon warehouse" is one phrase, but will count as 2 words.
+
+# Arguments
+- `kws::Vector{String}`: The vector of keywords being queried on.
+"""
+function split_keywords(kws::Vector{String})
+    MAX_WORDS = 60
+    split_num=0
+    splits=[]
+    cur_split=[]
+    for w in kws
+        w_count = 1+count(i->(i==' '), w)
+
+        if w_count > MAX_WORDS
+            throw("One of the key phrases exceeds the word limit of $(MAX_WORDS)")
+        end
+
+        if split_num + w_count <= MAX_WORDS
+            split_num = split_num + w_count
+            push!(cur_split, w)
+        else 
+            push!(splits, cur_split)
+            cur_split = [w]
+            split_num = w_count
+        end
+    end
+    push!(splits, cur_split)
+    return splits
+end
+


### PR DESCRIPTION
splits long lists of keywords into batches and runs them each. Then rejoins the batches and filters for unique articles.